### PR TITLE
Perform periodic rescanning when configured

### DIFF
--- a/.roo/mcp.json
+++ b/.roo/mcp.json
@@ -1,0 +1,1 @@
+{"mcpServers":{}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "serde_json",
  "small_ctor",
  "strum 0.27.1",
+ "sysinfo",
  "tempfile",
  "thiserror 2.0.12",
  "tiktoken-rs",
@@ -6109,6 +6110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6245,6 +6255,25 @@ checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
  "objc_exception",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -8951,6 +8980,20 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aab138f5c1bb35231de19049060a87977ad23e04f2303e953bc5c2947ac7dec4"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "cfg-if",
  "http 1.3.1",
  "indexmap 2.9.0",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "serde_qs",
@@ -1707,6 +1707,7 @@ dependencies = [
  "futures",
  "helmet-core",
  "http 1.3.1",
+ "humantime",
  "lancedb",
  "listenfd",
  "opentelemetry",
@@ -1718,7 +1719,7 @@ dependencies = [
  "rustls 0.23.28",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -7856,7 +7857,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.9.1",
  "rmcp-macros",
- "schemars",
+ "schemars 0.9.0",
  "serde",
  "serde_json",
  "sse-stream",
@@ -8192,6 +8193,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8385,16 +8398,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
- "schemars",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -8404,9 +8418,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/crates/breeze-indexer/Cargo.toml
+++ b/crates/breeze-indexer/Cargo.toml
@@ -75,6 +75,7 @@ serde.workspace = true
 serde_json.workspace = true
 small_ctor = "0.1.2"
 strum = { version = "0.27.1", features = ["derive"] }
+sysinfo = "0.36.0"
 tempfile = "3"
 thiserror = "2.0"
 

--- a/crates/breeze-indexer/src/file_watcher.rs
+++ b/crates/breeze-indexer/src/file_watcher.rs
@@ -8,9 +8,10 @@ use notify::{
   event::{CreateKind, DataChange, ModifyKind},
 };
 use notify_debouncer_full::{DebounceEventResult, Debouncer, FileIdMap};
+use sysinfo::{Pid, System};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 use uuid::Uuid;
 
 use crate::{IndexerError, task_manager::TaskManager};
@@ -64,9 +65,15 @@ impl ProjectWatcher {
       Duration::from_secs(2)
     };
 
-    let config = Config::default()
-      .with_poll_interval(poll_interval)
-      .with_compare_contents(true);
+    let config = Config::default();
+    // .with_poll_interval(poll_interval)
+    // .with_compare_contents(true);
+
+    // Added logging for diagnosis
+    debug!(
+      "Watcher config: poll_interval={:?}, compare_contents=false",
+      poll_interval
+    );
 
     let mut debouncer =
       notify_debouncer_full::new_debouncer_opt(
@@ -166,6 +173,17 @@ impl ProjectWatcher {
     // Start watching
     debouncer.watch(project_path, RecursiveMode::Recursive)?;
 
+    // Added logging to monitor open files - requires sysinfo crate
+    // Note: Add sysinfo to Cargo.toml dependencies for this to work
+    let system = System::new_all();
+    let pid = std::process::id();
+    if let Some(process) = system.process(Pid::from_u32(pid)) {
+      debug!(
+        "Open files after watch setup: {}",
+        process.open_files().unwrap_or_default()
+      );
+    }
+
     Ok(Self {
       project_id,
 
@@ -183,6 +201,16 @@ impl ProjectWatcher {
   pub async fn wait_for_shutdown(&self, shutdown: CancellationToken) {
     shutdown.cancelled().await;
     info!("File watcher shutting down for project {}", self.project_id);
+
+    // Added logging for shutdown FD check
+    let system = System::new_all();
+    let pid = std::process::id();
+    if let Some(process) = system.process(Pid::from_u32(pid)) {
+      debug!(
+        "Open files at shutdown: {}",
+        process.open_files().unwrap_or_default()
+      );
+    }
   }
 }
 

--- a/crates/breeze-indexer/src/file_watcher.rs
+++ b/crates/breeze-indexer/src/file_watcher.rs
@@ -46,12 +46,12 @@ impl ProjectWatcher {
     let project_id_clone = project_id;
     let project_path_clone = project_path_buf.clone();
 
-    // Create debouncer with 1 second timeout
-    let poll_interval = if cfg!(test) {
-      Duration::from_millis(100)
-    } else {
-      Duration::from_secs(3600) // 1 hour
-    };
+    // // Create debouncer with 1 second timeout
+    // let poll_interval = if cfg!(test) {
+    //   Duration::from_millis(100)
+    // } else {
+    //   Duration::from_secs(3600) // 1 hour
+    // };
 
     let debounce_timeout = if cfg!(test) {
       Duration::from_millis(500) // Much faster for tests
@@ -70,10 +70,10 @@ impl ProjectWatcher {
     // .with_compare_contents(true);
 
     // Added logging for diagnosis
-    debug!(
-      "Watcher config: poll_interval={:?}, compare_contents=false",
-      poll_interval
-    );
+    // debug!(
+    //   "Watcher config: poll_interval={:?}, compare_contents=false",
+    //   poll_interval
+    // );
 
     let mut debouncer =
       notify_debouncer_full::new_debouncer_opt(

--- a/crates/breeze-indexer/src/file_watcher.rs
+++ b/crates/breeze-indexer/src/file_watcher.rs
@@ -228,12 +228,18 @@ mod tests {
     let (_temp_dir_config, config) = Config::test();
     let embedding_provider = create_embedding_provider(&config).await.unwrap();
 
+    let project_table = crate::models::Project::ensure_table(&connection, "test_projects")
+      .await
+      .unwrap();
+    let project_table = Arc::new(RwLock::new(project_table));
+
     let bulk_indexer = BulkIndexer::new(
       Arc::new(config),
       Arc::from(embedding_provider),
       384,
       code_table.clone(),
       chunk_table,
+      project_table,
     );
 
     let project_table = crate::models::Project::ensure_table(&connection, "test_projects")

--- a/crates/breeze-indexer/src/indexer.rs
+++ b/crates/breeze-indexer/src/indexer.rs
@@ -347,7 +347,7 @@ impl Indexer {
       return Ok(());
     }
 
-    // self.start_all_project_watchers().await?;
+    self.start_all_project_watchers().await?;
 
     // Start worker task
     let worker_shutdown = self.shutdown_token.clone();
@@ -372,7 +372,7 @@ impl Indexer {
 
   /// Stop the indexer
   pub fn stop(&self) {
-    // self.stop_all_watchers();
+    self.stop_all_watchers();
     self.shutdown_token.cancel();
   }
 } // This closing brace belongs to the `impl Indexer` block

--- a/crates/breeze-indexer/src/indexer.rs
+++ b/crates/breeze-indexer/src/indexer.rs
@@ -347,7 +347,7 @@ impl Indexer {
       return Ok(());
     }
 
-    self.start_all_project_watchers().await?;
+    // self.start_all_project_watchers().await?;
 
     // Start worker task
     let worker_shutdown = self.shutdown_token.clone();
@@ -372,7 +372,7 @@ impl Indexer {
 
   /// Stop the indexer
   pub fn stop(&self) {
-    self.stop_all_watchers();
+    // self.stop_all_watchers();
     self.shutdown_token.cancel();
   }
 } // This closing brace belongs to the `impl Indexer` block

--- a/crates/breeze-indexer/src/lib.rs
+++ b/crates/breeze-indexer/src/lib.rs
@@ -9,6 +9,7 @@ mod models;
 mod pipeline;
 mod project_manager;
 mod reqwestx;
+mod rescan_worker;
 mod sinks;
 mod task_manager;
 

--- a/crates/breeze-indexer/src/rescan_worker.rs
+++ b/crates/breeze-indexer/src/rescan_worker.rs
@@ -1,0 +1,96 @@
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::sleep;
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info};
+
+use crate::{IndexerError, ProjectManager, TaskManager};
+
+/// Starts the rescan worker loop
+///
+/// This function runs a background task that periodically checks for projects
+/// that need rescanning and submits indexing tasks for them.
+///
+/// # Arguments
+///
+/// * `project_manager` - Shared reference to the ProjectManager
+/// * `task_manager` - Shared reference to the TaskManager
+/// * `interval` - Duration between rescan cycles
+/// * `shutdown_token` - Token to signal worker shutdown
+pub fn start_rescan_worker(
+  project_manager: Arc<ProjectManager>,
+  task_manager: Arc<TaskManager>,
+  interval: Duration,
+  shutdown_token: CancellationToken,
+) {
+  tokio::spawn(async move {
+    while !shutdown_token.is_cancelled() {
+      // Run rescan cycle
+      if let Err(e) = run_rescan_cycle(&project_manager, &task_manager).await {
+        error!("Rescan cycle failed: {}", e);
+      }
+
+      // Wait for interval or cancellation
+      tokio::select! {
+          _ = sleep(interval) => {},
+          _ = shutdown_token.cancelled() => break,
+      }
+    }
+    info!("Rescan worker shut down");
+  });
+}
+
+/// Runs a single rescan cycle
+///
+/// This function:
+/// 1. Finds projects that need rescanning
+/// 2. Submits indexing tasks for each project
+/// 3. Handles errors gracefully with proper logging
+async fn run_rescan_cycle(
+  project_manager: &ProjectManager,
+  task_manager: &TaskManager,
+) -> Result<(), IndexerError> {
+  let now = chrono::Utc::now();
+  let projects = project_manager.find_projects_needing_rescan(now).await?;
+
+  for project in projects {
+    let project_id = project.id;
+    let project_path = project.directory.clone();
+
+    info!(
+        project_id = %project_id,
+        project_name = %project.name,
+        "Submitting periodic rescan task for project"
+    );
+
+    // Submit a full index task for the rescan
+    // The TaskManager's existing deduplication logic will handle preventing duplicate tasks
+    match task_manager
+      .submit_task(
+        project_id,
+        Path::new(&project_path),
+        crate::models::TaskType::FullIndex,
+      )
+      .await
+    {
+      Ok(task_id) => {
+        info!(
+            project_id = %project_id,
+            task_id = %task_id,
+            "Successfully submitted rescan task"
+        );
+      }
+      Err(e) => {
+        error!(
+            project_id = %project_id,
+            error = %e,
+            "Failed to submit rescan task"
+        );
+        // Continue with other projects even if one fails
+      }
+    }
+  }
+
+  Ok(())
+}

--- a/crates/breeze-indexer/src/search.rs
+++ b/crates/breeze-indexer/src/search.rs
@@ -14,6 +14,7 @@ use lancedb::rerankers::rrf;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tracing::info;
+use uuid::Uuid;
 
 use crate::embeddings::EmbeddingProvider;
 use chunks::search_chunks;
@@ -104,7 +105,7 @@ async fn build_hybrid_query(
 ) -> Result<lancedb::query::VectorQuery> {
   let mut query_builder = table
     .query()
-    .only_if("project_id != '00000000-0000-0000-0000-000000000000'");
+    .only_if(format!("project_id != '{}'", Uuid::nil()));
 
   // Add project filter if provided
   if let Some(pid) = project_id {

--- a/crates/breeze-indexer/src/task_manager.rs
+++ b/crates/breeze-indexer/src/task_manager.rs
@@ -190,18 +190,11 @@ impl TaskManager {
     // On startup, reset any "running" tasks to "pending" (in case of crash)
     self.reset_stuck_tasks().await?;
 
-    let mut rescan_interval = tokio::time::interval(Duration::from_secs(60));
-
     loop {
       tokio::select! {
         _ = shutdown_token.cancelled() => {
           info!("Task worker shutting down");
           break;
-        }
-        _ = rescan_interval.tick() => {
-            if let Err(e) = self.check_and_submit_rescans().await {
-                error!("Error checking for rescans: {}", e);
-            }
         }
         _ = tokio::time::sleep(Duration::from_secs(1)) => {
           // Check for pending tasks
@@ -707,90 +700,6 @@ impl TaskManager {
       )
       .await
   }
-
-  /// Check for projects that need periodic rescanning and submit tasks for them
-  async fn check_and_submit_rescans(&self) -> Result<(), IndexerError> {
-    let project_table = self.project_table.read().await;
-    let now = chrono::Utc::now().naive_utc();
-
-    // Query for active projects with rescan enabled and next_rescan_at in the past
-    let filter = format!(
-      "status = 'Active' AND rescan_enabled = true AND next_rescan_at <= timestamp '{}'",
-      now
-        .and_utc()
-        .to_rfc3339_opts(chrono::SecondsFormat::Micros, true)
-    );
-
-    let mut stream = project_table.query().only_if(&filter).execute().await?;
-
-    while let Some(batch) = stream.try_next().await? {
-      for i in 0..batch.num_rows() {
-        let project = Project::from_record_batch(&batch, i)?;
-        let project_id = project.id;
-        let project_path = project.directory.clone();
-
-        info!(
-          project_id = %project_id,
-          "Submitting periodic rescan task for project"
-        );
-
-        // Submit a full index task
-        match self
-          .submit_task(
-            project_id,
-            Path::new(&project_path),
-            crate::models::TaskType::FullIndex,
-          )
-          .await
-        {
-          Ok(_) => {
-            // Update the project's rescan timestamps
-            let last_rescan_at = chrono::Utc::now().naive_utc();
-            let next_rescan_at = if let Some(interval) = project.rescan_interval_minutes {
-              Some(last_rescan_at + chrono::Duration::minutes(i64::from(interval)))
-            } else {
-              None
-            };
-
-            let mut update_query = self
-              .project_table
-              .write()
-              .await
-              .update()
-              .only_if(format!("id = '{}'", project_id).as_str())
-              .column(
-                "last_rescan_at",
-                format!("{}", last_rescan_at.and_utc().timestamp_micros()),
-              );
-
-            if let Some(next) = next_rescan_at {
-              update_query = update_query.column(
-                "next_rescan_at",
-                format!("{}", next.and_utc().timestamp_micros()),
-              );
-            }
-
-            if let Err(e) = update_query.execute().await {
-              error!(
-                project_id = %project_id,
-                error = %e,
-                "Failed to update project rescan timestamps"
-              );
-            }
-          }
-          Err(e) => {
-            error!(
-              project_id = %project_id,
-              error = %e,
-              "Failed to submit rescan task"
-            );
-          }
-        }
-      }
-    }
-
-    Ok(())
-  }
 }
 
 #[cfg(test)]
@@ -840,12 +749,18 @@ mod tests {
 
     let embedding_provider = create_embedding_provider(&config).await.unwrap();
 
+    let project_table = crate::models::Project::ensure_table(&connection, "test_projects")
+      .await
+      .unwrap();
+    let project_table = Arc::new(RwLock::new(project_table));
+
     let bulk_indexer = BulkIndexer::new(
       Arc::new(config),
       Arc::from(embedding_provider),
       384,
       code_table.clone(),
       chunk_table,
+      project_table,
     );
 
     let project_table = crate::models::Project::ensure_table(&connection, "test_projects")

--- a/crates/breeze-server/Cargo.toml
+++ b/crates/breeze-server/Cargo.toml
@@ -22,6 +22,7 @@ futures.workspace = true
 
 helmet-core = "0.2.0"
 http.workspace = true
+humantime = "2.2.0"
 lancedb = { workspace = true }
 
 listenfd = "1"

--- a/crates/breeze-server/src/duration.rs
+++ b/crates/breeze-server/src/duration.rs
@@ -1,0 +1,89 @@
+use std::fmt;
+use std::ops::Deref;
+use std::str::FromStr;
+use std::time::Duration;
+
+use schemars::{JsonSchema, json_schema};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// A wrapper around Duration that serializes/deserializes as human-readable strings
+/// like "1h", "30m", "2h30m", etc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HumanDuration(pub Duration);
+
+impl HumanDuration {
+  pub fn new(duration: Duration) -> Self {
+    HumanDuration(duration)
+  }
+
+  pub fn inner(&self) -> Duration {
+    self.0
+  }
+}
+
+impl Deref for HumanDuration {
+  type Target = Duration;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl From<Duration> for HumanDuration {
+  fn from(duration: Duration) -> Self {
+    HumanDuration(duration)
+  }
+}
+
+impl From<HumanDuration> for Duration {
+  fn from(human: HumanDuration) -> Self {
+    human.0
+  }
+}
+
+impl fmt::Display for HumanDuration {
+  fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+    write!(f, "{}", humantime::format_duration(self.0))
+  }
+}
+
+impl FromStr for HumanDuration {
+  type Err = humantime::DurationError;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    humantime::parse_duration(s).map(HumanDuration)
+  }
+}
+
+impl Serialize for HumanDuration {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_str(&self.to_string())
+  }
+}
+
+impl<'de> Deserialize<'de> for HumanDuration {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'de>,
+  {
+    let s = String::deserialize(deserializer)?;
+    HumanDuration::from_str(&s).map_err(serde::de::Error::custom)
+  }
+}
+
+impl JsonSchema for HumanDuration {
+  fn schema_name() -> std::borrow::Cow<'static, str> {
+    std::borrow::Cow::Borrowed("HumanDuration")
+  }
+
+  fn json_schema(_gen: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    json_schema!({
+      "type": "string",
+      "description": "Human-readable duration string (e.g. '1h', '30m', '1h 30m', '90s')",
+      "examples": ["1h", "30m", "1h 30m", "90s", "2d 3h", "1w"]
+    })
+  }
+}

--- a/crates/breeze-server/src/lib.rs
+++ b/crates/breeze-server/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+mod duration;
 mod error;
 mod mcp;
 mod routes;

--- a/crates/breeze-server/src/mcp.rs
+++ b/crates/breeze-server/src/mcp.rs
@@ -33,6 +33,7 @@ impl BreezeService {
       name,
       directory,
       description,
+      rescan_interval,
     }: CreateProjectRequest,
   ) -> Result<CallToolResult, McpError> {
     info!("Creating project: {} at {}", name, directory);
@@ -40,7 +41,7 @@ impl BreezeService {
     match self
       .indexer
       .project_manager()
-      .create_project(name, directory, description)
+      .create_project(name, directory, description, rescan_interval.map(|v| *v))
       .await
     {
       Ok(project) => Ok(CallToolResult::success(vec![Content::text(format!(
@@ -156,6 +157,7 @@ impl BreezeService {
       project_id,
       name,
       description,
+      rescan_interval,
     }: UpdateProjectByIdRequest,
   ) -> Result<CallToolResult, McpError> {
     info!("Updating project: {}", project_id);
@@ -173,7 +175,7 @@ impl BreezeService {
     match self
       .indexer
       .project_manager()
-      .update_project(project_uuid, name, description)
+      .update_project(project_uuid, name, description, rescan_interval.map(|v| *v))
       .await
     {
       Ok(Some(project)) => Ok(CallToolResult::success(vec![Content::text(format!(

--- a/crates/breeze-server/src/routes.rs
+++ b/crates/breeze-server/src/routes.rs
@@ -150,7 +150,12 @@ async fn create_project(
   match state
     .indexer
     .project_manager()
-    .create_project(req.name, req.directory, req.description)
+    .create_project(
+      req.name,
+      req.directory,
+      req.description,
+      req.rescan_interval.map(|v| *v),
+    )
     .await
   {
     Ok(project) => {
@@ -190,7 +195,12 @@ async fn update_project(
   match state
     .indexer
     .project_manager()
-    .update_project(id, req.name, req.description)
+    .update_project(
+      id,
+      req.name,
+      req.description,
+      req.rescan_interval.map(|v| *v),
+    )
     .await
   {
     Ok(Some(project)) => Json(Into::<Project>::into(project)).into_response(),

--- a/crates/breeze-server/src/types.rs
+++ b/crates/breeze-server/src/types.rs
@@ -4,6 +4,8 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use crate::duration::HumanDuration;
+
 // Note: These types are shared between the REST API and MCP server
 // JsonSchema is used for both MCP and future OpenAPI spec generation
 
@@ -13,6 +15,7 @@ pub struct CreateProjectRequest {
   pub name: String,
   pub directory: String,
   pub description: Option<String>,
+  pub rescan_interval: Option<HumanDuration>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -23,6 +26,7 @@ pub struct Project {
   pub description: Option<String>,
   pub created_at: chrono::NaiveDateTime,
   pub updated_at: chrono::NaiveDateTime,
+  pub rescan_interval: Option<HumanDuration>,
 }
 
 impl From<breeze_indexer::Project> for Project {
@@ -34,6 +38,7 @@ impl From<breeze_indexer::Project> for Project {
       description: project.description,
       created_at: project.created_at,
       updated_at: project.updated_at,
+      rescan_interval: project.rescan_interval.map(HumanDuration::from),
     }
   }
 }
@@ -42,6 +47,7 @@ impl From<breeze_indexer::Project> for Project {
 pub struct UpdateProjectRequest {
   pub name: Option<String>,
   pub description: Option<Option<String>>,
+  pub rescan_interval: Option<HumanDuration>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
@@ -172,6 +178,7 @@ pub struct UpdateProjectByIdRequest {
   pub project_id: String,
   pub name: Option<String>,
   pub description: Option<Option<String>>,
+  pub rescan_interval: Option<HumanDuration>,
 }
 
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]

--- a/crates/breeze/src/app.rs
+++ b/crates/breeze/src/app.rs
@@ -42,6 +42,7 @@ impl App {
       name,
       directory,
       description,
+      rescan_interval: None, // Default to no rescan interval
     };
 
     let response = self
@@ -97,6 +98,7 @@ impl App {
     let req = UpdateProjectRequest {
       name,
       description: description.map(Some),
+      rescan_interval: None, // Default to no rescan interval
     };
 
     let response = self


### PR DESCRIPTION
- Introduced `rescan_interval` as an optional field in the Project struct.
- Updated project creation and update methods to handle rescan intervals.
- Implemented a new rescan worker to periodically check for projects needing rescanning.
- Added database query logic to find projects that require rescanning based on their last indexed time and rescan interval.
- Created a HumanDuration type for better handling of human-readable duration strings.
- Updated server routes and request/response types to include rescan interval.
- Refactored task manager to remove old rescan logic and integrate with the new rescan worker.
- Added tests for rescan functionality, including edge cases and interval calculations.